### PR TITLE
Develop box factory

### DIFF
--- a/bounding_box.py
+++ b/bounding_box.py
@@ -90,6 +90,7 @@ class Box(object):
         self._metadata = utilities.Bunch(
             box_id=binascii.b2a_hex(os.urandom(15)),
             history=[],
+            construction_request=None       # used to store raw request made by factory if box was created in a factory
             starting_box_tl=box_tl,
             starting_dims=dims
         )

--- a/box_factory.py
+++ b/box_factory.py
@@ -144,6 +144,8 @@ class BoxFactory(object):
             box_tl = request[0]
             box_dims = request[1]
             box = bounding_box.Box(self._s_map, box_tl, box_dims, self._min_size)
+            # add request metadata
+            box.metadata.construction_request = request
             boxes_list.append(box)
         return boxes_list
         


### PR DESCRIPTION
BoxFactory: creates a list of template boxes given a list of "requests". Requests are formed of two elements: position and dimension. Position is given by keyword: "tl"="top left" & "c" = centered" etc. Dimension is given either as ndarray (50,25) = 50 tall 25 wide (uses (i,j) convention), or as a fraction between 0 & 1 as a scale factor of the image : e.g 0.2 = 20% the size of the image (preserves image aspect). 

Also added additional metadata to indicate that a box was made by the factory: metadata now contains the "request" that generated the box. Allows us to use for save-file names later!